### PR TITLE
Widgets should be created in heap

### DIFF
--- a/src/app/preview-qt/main.cpp
+++ b/src/app/preview-qt/main.cpp
@@ -83,9 +83,10 @@ int main(int argc, char **argv)
         }
         QSurfaceFormat::setDefaultFormat(fmt);
 
-        GLWidget glWidget; // Note: moved creation output of Window for signal connection:
+        // Should be created in heap, ownership taken by parent widget
+        GLWidget *glWidget = new GLWidget; // Note: moved creation output of Window for signal connection:
 
-        MainWindow mainWindow(&glWidget);
+        MainWindow mainWindow(glWidget);
         mainWindow.resize(mainWindow.sizeHint());
         int desktopArea = QApplication::desktop()->width() * QApplication::desktop()->height();
         int widgetArea = mainWindow.width() * mainWindow.height();
@@ -106,7 +107,7 @@ int main(int argc, char **argv)
         QObject::connect(&capture, &VideoCapture::started, [](){ qDebug() << "capture started"; });
         QMetaObject::invokeMethod(&capture, "start");
 
-        glWidget.connect(&capture, SIGNAL(matReady(cv::Mat)), SLOT(setImage(cv::Mat)));
+        glWidget->connect(&capture, SIGNAL(matReady(cv::Mat)), SLOT(setImage(cv::Mat)));
 
         // ((((((((((((((((( eND )))))))))))))))))
         int rc = app.exec();


### PR DESCRIPTION
When child widget connects to parent, parent takes ownership and remove child
object in destructor. If widget created on stack then parent will try to free
chunk of stack memory.
