### PR TITLE
Add dummy Stop, Start, Record buttons

### DIFF
--- a/src/app/preview-qt/VideoCapture.cpp
+++ b/src/app/preview-qt/VideoCapture.cpp
@@ -46,7 +46,6 @@ void VideoCapture::timerEvent(QTimerEvent * ev)
     if (!getFrame(frame))
     { // Blocks until a new frame is ready
         std::cout << "Didn't capture frame " << std::endl;
-        m_timer.stop();
         return;
     }
     else

--- a/src/app/preview-qt/glwidget.cpp
+++ b/src/app/preview-qt/glwidget.cpp
@@ -143,6 +143,6 @@ void GLWidget::setImage(const cv::Mat &image)
 
      // Logging for now...
      if(!(m_counter++ % 100))
-         std::cout << "GLWidget: got image" << image.size() << std::endl;
+         std::cout << "GLWidget(" << m_counter << "): got image " << image.size() << std::endl;
      update();
 }

--- a/src/app/preview-qt/window.cpp
+++ b/src/app/preview-qt/window.cpp
@@ -52,15 +52,28 @@
 
 Window::Window(MainWindow *mw, GLWidget *glWidget) : mainWindow(mw), glWidget(glWidget)
 {
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+    QWidget *buttons = new QWidget;
+    QVBoxLayout *buttons_layout = new QVBoxLayout;
+
+    QPushButton *button_stop = new QPushButton;
+    QPushButton *button_start = new QPushButton;
+    QPushButton *button_record = new QPushButton;
+
+    button_stop->setText("Stop");
+    button_start->setText("Start");
+    button_record->setText("Record");
+
+    buttons_layout->addWidget(button_stop);
+    buttons_layout->addWidget(button_start);
+    buttons_layout->addWidget(button_record);
+
+    buttons->setLayout(buttons_layout);
+
     QHBoxLayout *container = new QHBoxLayout;
     container->addWidget(glWidget);
+    container->addWidget(buttons);
 
-    QWidget *w = new QWidget;
-    w->setLayout(container);
-    mainLayout->addWidget(w);
-
-    setLayout(mainLayout);
+    setLayout(container);
 
     setWindowTitle(tr("Hello GL"));
 }


### PR DESCRIPTION
I don't know is it a bug or feature but if there is only OpenGL widget in layout the "W" problem will occur on iOS. You can reproduce this error in `hellogl2` example by removing next lines:

``` cpp
containter->addWidget(xSlider);
containter->addWidget(ySlider);
containter->addWidget(zSlider);

mainLayout->addWidget(dockBtn);
```

For now nothing will happen if you touch buttons, they only used to solve "The W" problem.
