### PR TITLE
Run camera_test on Android using CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,8 @@ include_directories(src/3rdparty/ogles_gpgpu)
 include_directories(src/3rdparty/ogles_gpgpu/ogles_gpgpu)
 include_directories(src/3rdparty/ogles_gpgpu/ogles_gpgpu/common)
 
+enable_testing()
+
 ### Manage libs and source code in src folder
 add_subdirectory(src)
 

--- a/src/app/camera_test/CMakeLists.txt
+++ b/src/app/camera_test/CMakeLists.txt
@@ -8,3 +8,12 @@ endif()
 
 install(TARGETS camera_test DESTINATION bin)
 set_property(TARGET camera_test PROPERTY FOLDER "app/console")
+
+if(ANDROID)
+  hunter_add_package(Android-Apk)
+  list(APPEND CMAKE_MODULE_PATH "${ANDROID-APK_ROOT}")
+
+  include(AndroidApk)
+
+  android_add_test(NAME CameraTest COMMAND camera_test)
+endif()


### PR DESCRIPTION
Probably it's broken by design since there is no manifest file. Added for consistency so it can be launched and error can be read from log.
