### PR TITLE
Fix qt-camera runtime error on iOS

### DIFF
--- a/src/app/qt-camera/main.cpp
+++ b/src/app/qt-camera/main.cpp
@@ -41,9 +41,13 @@
 #include "camera.h"
 
 #include <QApplication>
+#include <QtGlobal> // Q_OS_IOS
 
-int main(int argc, char *argv[])
-{
+#if defined(Q_OS_IOS)
+extern "C" int qtmn(int argc, char** argv) {
+#else
+  int main(int argc, char **argv) {
+#endif
     QApplication app(argc, argv);
 
     Camera camera;


### PR DESCRIPTION
Now I've noticed another runtime error:

```
qt-camera[1322:996513] _BSMachError: (os/kern) invalid capability (20)
qt-camera[1322:996513] _BSMachError: (os/kern) invalid name (15)
```

will try to use different deployment target
