### PR TITLE
Revert Qt's version

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -34,7 +34,7 @@ hunter_config(TIFF VERSION 4.0.2-p3)
 hunter_config(cereal VERSION 1.1.2-p5)
 hunter_config(OpenCV VERSION 3.0.0-p6 CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
 hunter_config(spdlog VERSION 1.0.0-p0)
-hunter_config(Qt VERSION 5.5.1-cvpixelbuffer-p0)
+hunter_config(Qt VERSION ${HUNTER_Qt_VERSION})
 
 #  CMAKE_ARGS 
 #  CMAKE_REQUIRED_FLAGS "-Wno-error=unused-command-line-argument-hard-error-in-future"

--- a/src/app/qmlvideofilter/VideoFilterRunnable.cpp
+++ b/src/app/qmlvideofilter/VideoFilterRunnable.cpp
@@ -157,9 +157,7 @@ bool VideoFilterRunnable::isFrameValid(const QVideoFrame& frame) {
   if (frame.handleType() == QAbstractVideoBuffer::GLTextureHandle) {
     return true;
   }
-  if (frame.handleType() == QAbstractVideoBuffer::CVPixelBufferHandle) {
-    return true;
-  }
+
   return false;
 }
 
@@ -196,14 +194,12 @@ GLuint VideoFilterRunnable::createTextureForFrame(QVideoFrame* input) {
   }
 
 #if USE_OGLES_GPGPU
-  if (input->handleType() == QAbstractVideoBuffer::CVPixelBufferHandle) {
-    void* pixelBuffer = input->handle().value<void*>();
-    cv::Size frameSize(input->size().width(), input->size().height());
-    m_pipeline->captureOutput(frameSize, pixelBuffer);
-    // TODO: Here we need to prevent the render to display and return a handle to the final render to texture.
-    return m_pipeline->getTexture();
-  }
-#endif
+  void* pixelBuffer = 0; // TODO run map and build
+  cv::Size frameSize(input->size().width(), input->size().height());
+  m_pipeline->captureOutput(frameSize, pixelBuffer);
+  // TODO: Here we need to prevent the render to display and return a handle to the final render to texture.
+  return m_pipeline->getTexture();
+#else
 
   assert(input->handleType() == QAbstractVideoBuffer::NoHandle);
 
@@ -255,4 +251,5 @@ GLuint VideoFilterRunnable::createTextureForFrame(QVideoFrame* input) {
 
   GATHERER_OPENGL_DEBUG;
   return m_tempTexture;
+#endif
 }

--- a/src/app/qmlvideofilter/main.qml
+++ b/src/app/qmlvideofilter/main.qml
@@ -54,6 +54,7 @@ Item {
 
   VideoFilter {
     id: videofilter
+    active: false
     // Animate a property which is passed to filter.
     SequentialAnimation on factor {
       loops: Animation.Infinite


### PR DESCRIPTION
- Revert Qt's version
- Remove experimental type `QAbstractVideoBuffer::CVPixelBufferHandle`
- Set video filter default state at start as disabled so we can check that camera is working good without filter
