### PR TITLE
Add class CVPixelBufferWrapper

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -34,7 +34,7 @@ hunter_config(TIFF VERSION 4.0.2-p3)
 hunter_config(cereal VERSION 1.1.2-p5)
 hunter_config(OpenCV VERSION 3.0.0-p6 CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
 hunter_config(spdlog VERSION 1.0.0-p0)
-hunter_config(Qt VERSION 5.5.1-cvpixelbuffer-p0)
+hunter_config(Qt VERSION ${HUNTER_Qt_VERSION})
 
 #  CMAKE_ARGS 
 #  CMAKE_REQUIRED_FLAGS "-Wno-error=unused-command-line-argument-hard-error-in-future"

--- a/src/app/qmlvideofilter/CMakeLists.txt
+++ b/src/app/qmlvideofilter/CMakeLists.txt
@@ -25,6 +25,10 @@ set(
     main.qml
 )
 
+if(IOS)
+  list(APPEND sources CVPixelBufferWrapper.hpp CVPixelBufferWrapper.mm)
+endif()
+
 if(ANDROID)
   add_library(qmlvideofilter SHARED ${sources})
 

--- a/src/app/qmlvideofilter/CVPixelBufferWrapper.hpp
+++ b/src/app/qmlvideofilter/CVPixelBufferWrapper.hpp
@@ -1,0 +1,24 @@
+#ifndef QMLVIDEOFILTER_CVPIXELBUFFER_WRAPPER_HPP_
+#define QMLVIDEOFILTER_CVPIXELBUFFER_WRAPPER_HPP_
+
+class QVideoFrame;
+
+class CVPixelBufferWrapper {
+ public:
+  CVPixelBufferWrapper(QVideoFrame& frame);
+
+  CVPixelBufferWrapper(const CVPixelBufferWrapper&) = delete;
+  CVPixelBufferWrapper& operator= (const CVPixelBufferWrapper&) = delete;
+
+  void* getCVPixelBufferRef() const {
+    return pixelBuffer_;
+  }
+
+  ~CVPixelBufferWrapper();
+
+ private:
+  QVideoFrame& frame_;
+  void* pixelBuffer_; // instance of CVPixelBufferRef
+};
+
+#endif // QMLVIDEOFILTER_CVPIXELBUFFER_WRAPPER_HPP_

--- a/src/app/qmlvideofilter/CVPixelBufferWrapper.mm
+++ b/src/app/qmlvideofilter/CVPixelBufferWrapper.mm
@@ -1,0 +1,38 @@
+#include "CVPixelBufferWrapper.hpp"
+
+#include <QVideoFrame>
+#include <cassert> // assert
+
+#import <CoreVideo/CoreVideo.h> // CVPixelBufferCreateWithBytes
+
+CVPixelBufferWrapper::CVPixelBufferWrapper(QVideoFrame& frame):
+    frame_(frame),
+    pixelBuffer_(nullptr) {
+  bool ok = frame_.map(QAbstractVideoBuffer::ReadOnly);
+  assert(ok);
+
+  CVPixelBufferRef x;
+  auto result = CVPixelBufferCreateWithBytes(
+      kCFAllocatorDefault,
+      frame_.size().width(),
+      frame_.size().height(),
+      kCVPixelFormatType_32BGRA,
+      frame_.bits(),
+      frame_.bytesPerLine(),
+      nullptr, // releaseCallback
+      nullptr, // releaseRefCon
+      nullptr, // pixelBufferAttributes
+      &x
+  );
+
+  assert(result == kCVReturnSuccess);
+  assert(x != nullptr);
+
+  pixelBuffer_ = x;
+}
+
+CVPixelBufferWrapper::~CVPixelBufferWrapper() {
+  CVPixelBufferRef x = (CVPixelBufferRef)pixelBuffer_;
+  CVPixelBufferRelease(x);
+  frame_.unmap();
+}

--- a/src/app/qmlvideofilter/TextureBuffer.hpp
+++ b/src/app/qmlvideofilter/TextureBuffer.hpp
@@ -40,6 +40,7 @@
 class TextureBuffer: public QAbstractVideoBuffer {
  public:
   TextureBuffer(uint id): QAbstractVideoBuffer(GLTextureHandle), id_(id) {
+    assert(id != 0);
   }
 
   static QVideoFrame::PixelFormat qtTextureFormat() {

--- a/src/app/qmlvideofilter/VideoFilterRunnable.cpp
+++ b/src/app/qmlvideofilter/VideoFilterRunnable.cpp
@@ -41,6 +41,10 @@
 #include "VideoFilter.hpp"
 #include "TextureBuffer.hpp"
 
+#if GATHERER_IOS
+# include "CVPixelBufferWrapper.hpp"
+#endif
+
 #include "libyuv.h"
 
 #if USE_OGLES_GPGPU
@@ -193,10 +197,10 @@ GLuint VideoFilterRunnable::createTextureForFrame(QVideoFrame* input) {
     return texture;
   }
 
-#if USE_OGLES_GPGPU
-  void* pixelBuffer = 0; // TODO run map and build
+#if USE_OGLES_GPGPU && GATHERER_IOS
+  CVPixelBufferWrapper bufferWrapper(*input);
   cv::Size frameSize(input->size().width(), input->size().height());
-  m_pipeline->captureOutput(frameSize, pixelBuffer);
+  m_pipeline->captureOutput(frameSize, bufferWrapper.getCVPixelBufferRef());
   // TODO: Here we need to prevent the render to display and return a handle to the final render to texture.
   return m_pipeline->getTexture();
 #else

--- a/src/app/qmlvideofilter/VideoFilterRunnable.cpp
+++ b/src/app/qmlvideofilter/VideoFilterRunnable.cpp
@@ -157,9 +157,7 @@ bool VideoFilterRunnable::isFrameValid(const QVideoFrame& frame) {
   if (frame.handleType() == QAbstractVideoBuffer::GLTextureHandle) {
     return true;
   }
-  if (frame.handleType() == QAbstractVideoBuffer::CVPixelBufferHandle) {
-    return true;
-  }
+
   return false;
 }
 
@@ -196,14 +194,12 @@ GLuint VideoFilterRunnable::createTextureForFrame(QVideoFrame* input) {
   }
 
 #if USE_OGLES_GPGPU
-  if (input->handleType() == QAbstractVideoBuffer::CVPixelBufferHandle) {
-    void* pixelBuffer = input->handle().value<void*>();
-    cv::Size frameSize(input->size().width(), input->size().height());
-    m_pipeline->captureOutput(frameSize, pixelBuffer);
-    // TODO: Here we need to prevent the render to display and return a handle to the final render to texture.
-    return m_pipeline->getTexture();
-  }
-#endif
+  void* pixelBuffer = 0; // TODO run map and build
+  cv::Size frameSize(input->size().width(), input->size().height());
+  m_pipeline->captureOutput(frameSize, pixelBuffer);
+  // TODO: Here we need to prevent the render to display and return a handle to the final render to texture.
+  return m_pipeline->getTexture();
+#else
 
   assert(input->handleType() == QAbstractVideoBuffer::NoHandle);
 
@@ -255,4 +251,5 @@ GLuint VideoFilterRunnable::createTextureForFrame(QVideoFrame* input) {
 
   GATHERER_OPENGL_DEBUG;
   return m_tempTexture;
+#endif
 }

--- a/src/app/qmlvideofilter/main.qml
+++ b/src/app/qmlvideofilter/main.qml
@@ -54,6 +54,7 @@ Item {
 
   VideoFilter {
     id: videofilter
+    active: false
     // Animate a property which is passed to filter.
     SequentialAnimation on factor {
       loops: Animation.Infinite

--- a/src/lib/graphics/gatherer_graphics.h
+++ b/src/lib/graphics/gatherer_graphics.h
@@ -19,8 +19,10 @@
 #elif __APPLE__
 #include "TargetConditionals.h"
 #if TARGET_OS_IPHONE && TARGET_IPHONE_SIMULATOR
+#  define GATHERER_IOS 1
 // define something for simulator
 #elif TARGET_OS_IPHONE
+#  define GATHERER_IOS 1
 #  include <OpenGLES/ES2/gl.h>
 #  include <OpenGLES/ES2/glext.h>
 #  include <arm_neon.h>


### PR DESCRIPTION
Results:
- Version without filter works as expected
- Version with filter doesn't produce runtime errors. It means for example that texture cache created successfully
- OGLES breaks some Qt's stuff, screenshot:
  ![img_2301](https://cloud.githubusercontent.com/assets/4346993/11879225/b223d9b0-a52c-11e5-9ddc-b4d730481778.jpg)
- After disabling `gpgpuMngr->process();` and `outputDispRenderer->render();` (set `return` in https://github.com/headupinclouds/gatherer/blob/97dfb8807bb0b7f907827b203a434254dff6706b/src/app/qmlvideofilter/OGLESGPGPUTest.cpp#L130) output looks good but no camera frames and application crash because of memory leaks (too much memory usage)
