### PR TITLE
Expose filter result to QML widget

### DIFF
--- a/src/app/qmlvideofilter/VideoFilter.cpp
+++ b/src/app/qmlvideofilter/VideoFilter.cpp
@@ -45,3 +45,11 @@ void VideoFilter::setFactor(qreal v) {
     emit factorChanged();
   }
 }
+
+void VideoFilter::setOutputString(QString newOutput) {
+  if (m_outputString == newOutput) {
+    return;
+  }
+  m_outputString = newOutput;
+  emit outputStringChanged();
+}

--- a/src/app/qmlvideofilter/VideoFilter.hpp
+++ b/src/app/qmlvideofilter/VideoFilter.hpp
@@ -41,19 +41,31 @@
 class VideoFilter: public QAbstractVideoFilter {
   Q_OBJECT
   Q_PROPERTY(qreal factor READ factor WRITE setFactor NOTIFY factorChanged)
+  Q_PROPERTY(QString outputString READ outputString NOTIFY outputStringChanged)
 
  public:
-  VideoFilter() : m_factor(1) { }
+  VideoFilter() : m_factor(1), m_outputString("Filter output") {
+    connect(this, SIGNAL(updateOutputString(QString)), this, SLOT(setOutputString(QString)));
+  }
   qreal factor() const { return m_factor; }
   void setFactor(qreal v);
+
+  QString outputString() const { return m_outputString; }
 
   QVideoFilterRunnable *createFilterRunnable() Q_DECL_OVERRIDE;
 
  signals:
   void factorChanged();
+  void outputStringChanged();
+
+  void updateOutputString(QString newOutput);
+
+ public slots:
+  void setOutputString(QString newOutput);
 
  private:
   qreal m_factor;
+  QString m_outputString;
 };
 
 #endif // VIDEO_FILTER_HPP_

--- a/src/app/qmlvideofilter/VideoFilterRunnable.cpp
+++ b/src/app/qmlvideofilter/VideoFilterRunnable.cpp
@@ -49,6 +49,8 @@
 #include <opencv2/core.hpp>
 #include <opencv2/highgui.hpp>
 
+#include <QDateTime>
+
 struct QVideoFrameScopeMap
 {
     QVideoFrameScopeMap(QVideoFrame *frame, QAbstractVideoBuffer::MapMode mode) : frame(frame)
@@ -205,7 +207,8 @@ GLuint VideoFilterRunnable::createTextureForFrame(QVideoFrame* input) {
             m_outTexture = outputTexture;
         }
     }
-    
+
+    emit m_filter->updateOutputString(QDateTime::currentDateTime().toString());
     return m_outTexture;
 }
 

--- a/src/app/qmlvideofilter/main.qml
+++ b/src/app/qmlvideofilter/main.qml
@@ -123,6 +123,10 @@ Item {
       property int v
       text: (v != 0 ? v.toString() : "???" ) + " fps"
     }
+    Text {
+      color: "blue"
+      text: (videofilter.active && videofilter.outputString) ? videofilter.outputString : ""
+    }
   }
 
   MouseArea {


### PR DESCRIPTION
Example of printing some infromation from filter `run` method to QML widget. Currently datetime UTC string printed if filter is enabled.
