### PR TITLE
Link dependent library

### DIFF
--- a/src/lib/OGLESGPGPUTest/CMakeLists.txt
+++ b/src/lib/OGLESGPGPUTest/CMakeLists.txt
@@ -3,4 +3,4 @@ find_package(OpenCV REQUIRED)
 
 add_library(OGLESGPGPUTest OGLESGPGPUTest.h OGLESGPGPUTest.cpp)
 target_include_directories(OGLESGPGPUTest PUBLIC "${CMAKE_CURRENT_LIST_DIR}")
-target_link_libraries(OGLESGPGPUTest PUBLIC ${OpenCV_LIBS} ogles_gpgpu)
+target_link_libraries(OGLESGPGPUTest PUBLIC ${OpenCV_LIBS} ogles_gpgpu gatherer_graphics)


### PR DESCRIPTION
Library should be linked explicitly so requirements
like GATHERER_ENABLE_OPENGL_DEBUG definition used while compiling.
