### PR TITLE
Pr.thread.pool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 	url = https://github.com/headupinclouds/GPUImage.git
 [submodule "src/3rdparty/thread-pool-cpp"]
 	path = src/3rdparty/thread-pool-cpp
-	url = git@github.com:inkooboo/thread-pool-cpp.git
+	url = git@github.com:headupinclouds/thread-pool-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "src/3rdparty/GPUImage"]
 	path = src/3rdparty/GPUImage
 	url = https://github.com/headupinclouds/GPUImage.git
+[submodule "src/3rdparty/thread-pool-cpp"]
+	path = src/3rdparty/thread-pool-cpp
+	url = git@github.com:inkooboo/thread-pool-cpp.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
+add_subdirectory(3rdparty)
+include_directories("${CMAKE_SOURCE_DIR}/src/3rdparty/thread-pool-cpp/thread_pool")
+
 add_subdirectory(lib)
 add_subdirectory(app)
-add_subdirectory(3rdparty)
 
 if(BUILD_TESTS)
   add_subdirectory(tests)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -19,3 +19,5 @@ if(BUILD_QT)
 
   add_subdirectory(qmlvideofilter)
 endif()
+
+add_subdirectory(thread-pool)

--- a/src/app/thread-pool/CMakeLists.txt
+++ b/src/app/thread-pool/CMakeLists.txt
@@ -1,0 +1,5 @@
+#tests
+
+add_executable(test-thread-pool test-thread-pool.cpp)
+
+

--- a/src/app/thread-pool/test-thread-pool.cpp
+++ b/src/app/thread-pool/test-thread-pool.cpp
@@ -1,0 +1,210 @@
+// Example for C++11 hacking
+// https://github.com/headupinclouds/thread-pool-cpp/blob/master/tests/thread_pool.t.cpp
+
+#include <thread_pool.hpp>
+
+#include <thread>
+#include <future>
+#include <functional>
+
+#include <iostream>
+
+#include <stdexcept>
+#include <iostream>
+#include <sstream>
+
+#define ASSERT(expr) \
+    if (!(expr)) { \
+        std::ostringstream ss; \
+        ss << __FILE__ << ":" <<__LINE__ << " " << #expr; \
+        throw std::runtime_error(ss.str()); \
+    }
+
+template <typename TestFunc>
+inline void doTest(const char *name, TestFunc &&test) {
+    std::cout << " - test ( " << name;
+    try {
+        test();
+    } catch (const std::exception &e) {
+        std::cout << " => failed with: " << e.what() << " )" << std::endl;
+        throw;
+    }
+    std::cout << " => succeed )" << std::endl;
+}
+
+int run_benchmark();
+int run_test();
+
+int main(int argc, char **argv)
+{
+    run_test();
+    run_benchmark();
+}
+
+static const size_t CONCURRENCY = 16;
+static const size_t REPOST_COUNT = 1000000;
+
+struct Heavy
+{
+    bool verbose;
+    std::vector<char> resource;
+    
+    Heavy(bool verbose = false)
+    : verbose(verbose)
+    , resource(100*1024*1024)
+    {
+        if (verbose) {
+            std::cout << "heavy default constructor" << std::endl;
+        }
+    }
+    
+    Heavy(const Heavy &o)
+    : verbose(o.verbose)
+    , resource(o.resource)
+    {
+        if (verbose) {
+            std::cout << "heavy copy constructor" << std::endl;
+        }
+    }
+    
+    Heavy(Heavy &&o)
+    : verbose(o.verbose)
+    , resource(std::move(o.resource))
+    {
+        if (verbose) {
+            std::cout << "heavy move constructor" << std::endl;
+        }
+    }
+    
+    Heavy & operator==(const Heavy &o)
+    {
+        verbose = o.verbose;
+        resource = o.resource;
+        if (verbose) {
+            std::cout << "heavy copy operator" << std::endl;
+        }
+        return *this;
+    }
+    
+    Heavy & operator==(const Heavy &&o)
+    {
+        verbose = o.verbose;
+        resource = std::move(o.resource);
+        if (verbose) {
+            std::cout << "heavy move operator" << std::endl;
+        }
+        return *this;
+    }
+    
+    ~Heavy()
+    {
+        if (verbose) {
+            std::cout << "heavy destructor. " << (resource.size() ? "Owns resource" : "Doesn't own resource") << std::endl;
+        }
+    }
+};
+
+
+struct RepostJob
+{
+    //Heavy heavy;
+    ThreadPool *thread_pool;
+    volatile size_t counter;
+    long long int begin_count;
+    std::promise<void> *waiter;
+    
+    RepostJob(ThreadPool *thread_pool, std::promise<void> *waiter)
+    : thread_pool(thread_pool)
+    , counter(0)
+    , waiter(waiter)
+    {
+        begin_count = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    }
+    
+    void operator()()
+    {
+        if (counter++ < REPOST_COUNT) {
+            if (thread_pool) {
+                thread_pool->post(*this);
+                return;
+            }
+        }
+        else {
+            long long int end_count = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+            std::cout << "reposted " << counter
+            << " in " << (double)(end_count - begin_count)/(double)1000000 << " ms"
+            << std::endl;
+            waiter->set_value();
+        }
+    }
+};
+
+int run_benchmark()
+{
+    std::cout << "Benchmark job reposting" << std::endl;
+    
+    {
+        std::cout << "***thread pool cpp***" << std::endl;
+        
+        std::promise<void> waiters[CONCURRENCY];
+        ThreadPool thread_pool;
+        for (auto &waiter : waiters) {
+            thread_pool.post(RepostJob(&thread_pool, &waiter));
+        }
+        
+        for (auto &waiter : waiters) {
+            waiter.get_future().wait();
+        }
+    }
+    
+    return 0;
+}
+
+int run_test()
+{
+    std::cout << "*** Testing ThreadPool ***" << std::endl;
+    
+    doTest("post job", []() {
+        ThreadPool pool;
+        
+        std::packaged_task<int()> t([](){
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            return 42;
+        });
+        
+        std::future<int> r = t.get_future();
+        
+        pool.post(t);
+        
+        ASSERT(42 == r.get());
+    });
+    
+    doTest("process job", []() {
+        ThreadPool pool;
+        
+        std::future<int> r = pool.process([]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            return 42;
+        });
+        
+        ASSERT(42 == r.get());
+    });
+    
+    struct my_exception {};
+    
+    doTest("process job with exception", []() {
+        ThreadPool pool;
+        
+        std::future<int> r = pool.process([]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            throw my_exception();
+            return 42;
+        });
+        
+        try {
+            ASSERT(r.get() == 42 && !"should not be called, exception expected");
+        } catch (const my_exception &e) {
+        }
+    });
+    
+}

--- a/src/app/thread-pool/test-thread-pool.cpp
+++ b/src/app/thread-pool/test-thread-pool.cpp
@@ -175,6 +175,7 @@ int run_test()
         
         std::future<int> r = t.get_future();
         
+        // Note: fastest variant (compared to 'process()' given prepackaged task)
         pool.post(t);
         
         ASSERT(42 == r.get());
@@ -183,6 +184,7 @@ int run_test()
     doTest("process job", []() {
         MyThreadPool pool;
         
+        // Note: This method of posting job to thread pool is much slower than 'post()' due to std::future and
         std::future<int> r = pool.process([]() {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
             return 42;

--- a/src/app/thread-pool/test-thread-pool.cpp
+++ b/src/app/thread-pool/test-thread-pool.cpp
@@ -104,16 +104,17 @@ struct Heavy
     }
 };
 
+typedef ThreadPool<128> MyThreadPool;
 
 struct RepostJob
 {
     //Heavy heavy;
-    ThreadPool *thread_pool;
+    MyThreadPool *thread_pool;
     volatile size_t counter;
     long long int begin_count;
     std::promise<void> *waiter;
     
-    RepostJob(ThreadPool *thread_pool, std::promise<void> *waiter)
+    RepostJob(MyThreadPool *thread_pool, std::promise<void> *waiter)
     : thread_pool(thread_pool)
     , counter(0)
     , waiter(waiter)
@@ -147,7 +148,7 @@ int run_benchmark()
         std::cout << "***thread pool cpp***" << std::endl;
         
         std::promise<void> waiters[CONCURRENCY];
-        ThreadPool thread_pool;
+        MyThreadPool thread_pool;
         for (auto &waiter : waiters) {
             thread_pool.post(RepostJob(&thread_pool, &waiter));
         }
@@ -165,7 +166,7 @@ int run_test()
     std::cout << "*** Testing ThreadPool ***" << std::endl;
     
     doTest("post job", []() {
-        ThreadPool pool;
+        MyThreadPool pool;
         
         std::packaged_task<int()> t([](){
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -180,7 +181,7 @@ int run_test()
     });
     
     doTest("process job", []() {
-        ThreadPool pool;
+        MyThreadPool pool;
         
         std::future<int> r = pool.process([]() {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -193,7 +194,7 @@ int run_test()
     struct my_exception {};
     
     doTest("process job with exception", []() {
-        ThreadPool pool;
+        MyThreadPool pool;
         
         std::future<int> r = pool.process([]() {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -207,4 +208,5 @@ int run_test()
         }
     });
     
+    return 0;
 }

--- a/src/lib/graphics/GLWarpShader.cpp
+++ b/src/lib/graphics/GLWarpShader.cpp
@@ -57,7 +57,7 @@ void WarpShader::compileShadersPlanar()
     attributes.push_back( std::pair<int, const char*>(RenderTexture::ATTRIB_VERTEX, "position") );
     attributes.push_back( std::pair<int, const char*>(RenderTexture::ATTRIB_TEXTUREPOSITION, "inputTextureCoordinate") );
 
-    m_pPlanarShaderProgram = make_unique<gatherer::graphics::shader_prog>(vShaderStr, fShaderStr, attributes);
+    m_pPlanarShaderProgram = std::make_unique<gatherer::graphics::shader_prog>(vShaderStr, fShaderStr, attributes);
     m_PlanarUniformMVP = m_pPlanarShaderProgram->GetUniformLocation("modelViewProjMatrix");
     m_PlanarUniformTexture =  m_pPlanarShaderProgram->GetUniformLocation("texture");
     

--- a/src/lib/graphics/GLWarpShader.cpp
+++ b/src/lib/graphics/GLWarpShader.cpp
@@ -57,7 +57,7 @@ void WarpShader::compileShadersPlanar()
     attributes.push_back( std::pair<int, const char*>(RenderTexture::ATTRIB_VERTEX, "position") );
     attributes.push_back( std::pair<int, const char*>(RenderTexture::ATTRIB_TEXTUREPOSITION, "inputTextureCoordinate") );
 
-    m_pPlanarShaderProgram = std::make_unique<gatherer::graphics::shader_prog>(vShaderStr, fShaderStr, attributes);
+    m_pPlanarShaderProgram = make_unique<gatherer::graphics::shader_prog>(vShaderStr, fShaderStr, attributes);
     m_PlanarUniformMVP = m_pPlanarShaderProgram->GetUniformLocation("modelViewProjMatrix");
     m_PlanarUniformTexture =  m_pPlanarShaderProgram->GetUniformLocation("texture");
     


### PR DESCRIPTION
Added thread-pool-cpp submodule and test application for experimentation.  This currently compiles for C++11 targets (Xcode 7.2 (iOS and OS X w/ C++14 feature warning), and Android)   I have this in mind as a framework for offloading video processing tasks (such as CPU processing in the qmlvideofilter sample app).  C++11 workarounds for `initialized lama captures` may need to be added to accommodate more platforms at some point.
![c 14_extension](https://cloud.githubusercontent.com/assets/554720/12788305/0511bac0-ca67-11e5-99e4-6483b5edbe51.jpg)
